### PR TITLE
Introduce gitignore additions after 11ty integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,16 @@
+# Backup and temp files
 *~
 *#
-*.DS_Store
-*tmp/*
+
+# OS generated files
+.DS_Store
+
+# Development
+tmp/
 .cursor
-*node_modules/*
+
+# Dependencies
+node_modules/
+
+# Build output
+_site/


### PR DESCRIPTION
11ty autogenerates the `_site` directory and it doesn't need to be tracked by git.